### PR TITLE
Updating PyDark website

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,7 +878,7 @@ This is a catch-all category for things that don't fit anywhere else.
 [92]: http://libminx.org/
 [93]: http://melonjs.org/
 [94]: https://www.reddit.com/r/FreeGaming
-[95]: http://www.pydark.com/
+[95]: https://github.com/SirFroweey/PyDark
 [96]: https://libre.fm/
 [97]: https://commons.wikimedia.org/wiki/Main_Page
 [98]: https://soundcloud.com/groups/creative-commons


### PR DESCRIPTION
Old link is dead, now points to a generic "domains for sale" company.

Please note that I could not verify the project's license,
as mentioned in this issue: https://github.com/SirFroweey/PyDark/issues/8